### PR TITLE
Remove widget cache

### DIFF
--- a/includes/widgets/class-wpm-widget-language-switcher.php
+++ b/includes/widgets/class-wpm-widget-language-switcher.php
@@ -63,9 +63,9 @@ class WPM_Widget_Language_Switcher extends WPM_Widget {
 	 */
 	public function widget( $args, $instance ) {
 
-		if ( $this->get_cached_widget( $args ) ) {
-			return;
-		}
+		// if ( $this->get_cached_widget( $args ) ) {
+		// 	return;
+		// }
 
 		ob_start();
 
@@ -79,7 +79,7 @@ class WPM_Widget_Language_Switcher extends WPM_Widget {
 
 		echo $content;
 
-		$this->cache_widget( $args, $content );
+		// $this->cache_widget( $args, $content );
 
 	}
 }


### PR DESCRIPTION
Widget contents is different on every page. Therefore we can't use cache. Otherwise the links of the language switcher may link to the wrong pages.