### PR TITLE
Don't use esc_attr_e() on language code / name

### DIFF
--- a/templates/language-switcher-list.php
+++ b/templates/language-switcher-list.php
@@ -1,12 +1,12 @@
-<ul class="wpm-language-switcher switcher-<?php esc_attr_e( $type ); ?>">
+<ul class="wpm-language-switcher switcher-<?php echo esc_attr( $type ); ?>">
 	<?php foreach ( $languages as $code => $language ) { ?>
-		<li class="item-language-<?php esc_attr_e( $code ); ?><?php if ( $code === $lang ) { ?> active<?php } ?>">
-			<a href="<?php echo esc_url( wpm_translate_url( $current_url, $code ) ); ?>" data-lang="<?php esc_attr_e( $code ); ?>">
+		<li class="item-language-<?php echo esc_attr( $code ); ?><?php if ( $code === $lang ) { ?> active<?php } ?>">
+			<a href="<?php echo esc_url( wpm_translate_url( $current_url, $code ) ); ?>" data-lang="<?php echo esc_attr( $code ); ?>">
 				<?php if ( ( ( 'flag' === $show ) || ( 'both' === $show ) ) && ( $language['flag'] ) ) { ?>
-					<img src="<?php echo esc_url( wpm_get_flag_url( $language['flag'] ) ); ?>" alt="<?php esc_attr_e( $language['name'] ); ?>">
+					<img src="<?php echo esc_url( wpm_get_flag_url( $language['flag'] ) ); ?>" alt="<?php echo esc_attr( $language['name'] ); ?>">
 				<?php } ?>
 				<?php if ( ( 'name' === $show ) || ( 'both' === $show ) ) { ?>
-					<span><?php esc_attr_e( $language['name'] ); ?></span>
+					<span><?php echo esc_html( $language['name'] ); ?></span>
 				<?php } ?>
 			</a>
 		</li>


### PR DESCRIPTION
In the templates esc_attr_e() is used to escape the language code. This can potentially causes issues because worpress translates the language code as if it were a word (e.g. Amharic 'am' would be interpreted as in '9 am').

In the templates esc_attr_e() is used to escape the language name. Imho the language name should not be translated in the language switcher.

(this relates to all widget template files)