### PR TITLE
Fallback if translation is not found

### DIFF
--- a/includes/wpm-translation-functions.php
+++ b/includes/wpm-translation-functions.php
@@ -117,11 +117,20 @@ function wpm_translate_string( $string, $language = '' ) {
 	$language         = wpm_get_language();
 	$default_language = wpm_get_default_language();
 
-	if ( ( '' == $strings[ $language ] ) && get_option( 'wpm_show_untranslated_strings', 'yes' ) === 'yes' ) {
-		return $strings[ $default_language ];
+	if ( ( '' !== $strings[ $language ] ) || get_option( 'wpm_show_untranslated_strings', 'yes' ) !== 'yes' ) {
+		return $strings[ $language ];
 	}
-
-	return $strings[ $language ];
+	
+	//Fallback if translation is not found
+	if ( '' !== $strings[ $default_language ] ) {
+		return $strings[ $default_language ];
+	}	
+	foreach( $strings as $string ) {
+		if ( ( '' !== $string ) ) {
+			return $string;
+		}
+	}
+	return '';
 }
 
 /**


### PR DESCRIPTION
If both the translation to the requested language and the default language are not found, fallback to the first available translation.