### PR TITLE
Fix: fatal error when a plugin is updated or disabled

### DIFF
--- a/includes/class-wpm-setup.php
+++ b/includes/class-wpm-setup.php
@@ -111,7 +111,8 @@ class WPM_Setup {
 			add_filter( 'pre_option_home', array( $this, 'set_home_url' ), 99 );
 		}
 		add_action( 'after_switch_theme', array( __NAMESPACE__ . '\WPM_Config', 'load_config_run' ) );
-		add_action( 'activated_plugin', array( __NAMESPACE__ . '\WPM_Config', 'load_config_run' ) );
+		add_action( 'update_option_active_plugins', array( __NAMESPACE__ . '\WPM_Config', 'load_config_run' ) );
+		add_action( 'update_site_option_active_sitewide_plugins', array( __NAMESPACE__ . '\WPM_Config', 'load_config_run' ) );
 		add_action( 'upgrader_process_complete', array( __NAMESPACE__ . '\WPM_Config', 'load_config_run' ) );
 		add_action( 'wpm_init', array( $this, 'load_integrations' ) );
 		add_action( 'template_redirect', array( $this, 'redirect_default_url' ) );


### PR DESCRIPTION
WP-Multilang uses a cached version of 'active_plugins'. When a wp-multilang integrated plugin is disabled WP-Multilang may cause a Fatal Error if it tries to call a method from that plugin.

For example, I got this error when updating WooCommerce:

> Fatal error: Uncaught Error: Call to undefined function WPM\Includes\Integrations\wc_attribute_taxonomy_name() in /public_html/wp-content/plugins/wp-multilang/includes/integrations/class-wpm-woocommerce.php:161 
> Stack trace: 
> #0 /public_html/wp-includes/class-wp-hook.php(286): WPM\Includes\Integrations\WPM_WooCommerce->add_attribute_taxonomies(Array) 
> #1 /public_html/wp-includes/plugin.php(203): WP_Hook->apply_filters(Array, Array) 
> #2 /public_html/wp-content/plugins/wp-multilang/includes/wpm-config-functions.php(53): apply_filters('wpm_taxonomies_...', Array) 
> #3 /public_html/wp-content/plugins/wp-multilang/includes/wpm-translation-functions.php(434): wpm_get_taxonomy_config('') 
> #4 /public_html/wp-includes/class-wp-hook.php(286): wpm_translate_term(Object(WP_Term), '') 
> #5 /public_html/wp-includes/plugin.php(203): WP_Hook->apply_filters(Object(WP_Term), Array) 
> #6 /public_html/wp-includes/taxonomy.php(783): apply_filt in /public_html/wp-content/plugins/wp-multilang/includes/integrations/class-wpm-woocommerce.php on line 161

FIX: Reload active_plugins into cache whenever a plugin is (de)activated.
