### PR TITLE
Woo: Add woocommerce_format_content filter to translate

### DIFF
--- a/includes/integrations/class-wpm-woocommerce.php
+++ b/includes/integrations/class-wpm-woocommerce.php
@@ -23,6 +23,8 @@ class WPM_WooCommerce {
 	 * WPM_WooCommerce constructor.
 	 */
 	public function __construct() {
+		add_filter( 'woocommerce_short_description', 'wpm_translate_string' );
+		add_filter( 'woocommerce_format_content', 'wpm_translate_string' );
 		add_filter( 'woocommerce_product_get_name', 'wpm_translate_string' );
 		add_filter( 'woocommerce_product_get_description', 'wpm_translate_string' );
 		add_filter( 'woocommerce_product_get_short_description', 'wpm_translate_string' );

--- a/includes/integrations/class-wpm-woocommerce.php
+++ b/includes/integrations/class-wpm-woocommerce.php
@@ -23,7 +23,6 @@ class WPM_WooCommerce {
 	 * WPM_WooCommerce constructor.
 	 */
 	public function __construct() {
-		add_filter( 'woocommerce_short_description', 'wpm_translate_string' );
 		add_filter( 'woocommerce_format_content', 'wpm_translate_string' );
 		add_filter( 'woocommerce_product_get_name', 'wpm_translate_string' );
 		add_filter( 'woocommerce_product_get_description', 'wpm_translate_string' );


### PR DESCRIPTION
```bash
WordPress v5.2.1
WooCommerce v3.6.4
WP-Multilang v3.6.4
PHP v7.2.17-0ubuntu0.18.04.1
```
## Added two filters to translate

1. `woocommerce_short_description`
2. `woocommerce_format_content`

Woocommerce **v3.6.4**

### `woocommerce_short_description` applied in
```
includes\api\legacy\v1\class-wc-api-products.php
includes\api\legacy\v2\class-wc-api-products.php
includes\api\legacy\v3\class-wc-api-products.php
includes\api\v1\class-wc-rest-products-controller.php
includes\api\v2\class-wc-rest-products-v2-controller.php
includes\blocks\class-wc-block-featured-product.php
includes\wc-formatting-functions.php
templates\single-product\short-description.php
```
### `woocommerce_format_content` applied in
```
includes\wc-formatting-functions.php
```