### PR TITLE
Yoast SEO: Fix config options

### DIFF
--- a/configs/plugins/wordpress-seo.json
+++ b/configs/plugins/wordpress-seo.json
@@ -25,7 +25,14 @@
       "title-archive-wpseo" : {},
       "metadesc-archive-wpseo" : {},
       "title-search-wpseo" : {},
-      "title-404-wpseo" : {}
+      "title-404-wpseo" : {},
+      "breadcrumbs-home" : {},
+      "breadcrumbs-prefix" : {},
+      "breadcrumbs-archiveprefix" : {},
+      "breadcrumbs-searchprefix" : {},
+      "breadcrumbs-404crumb" : {},
+      "rssbefore" : {},
+      "rssafter" : {}
     },
     "wpseo_internallinks": {
       "breadcrumbs-home" : {},


### PR DESCRIPTION
```bash
WordPress v5.2.1
Yoast SEO 11.3
WP-Multilang v3.6.4
PHP v7.2.17-0ubuntu0.18.04.1
```

In Yoast SEO v11.3 no pages with ids `wpseo_internallinks` and `wpseo_rss`. Fields from this ids are in `wpseo_titles` page.