### PR TITLE
Fix remove necessary slashes from languages that are not currently edited (Carbon Fields rich text)

### DIFF
--- a/includes/wpm-translation-functions.php
+++ b/includes/wpm-translation-functions.php
@@ -562,8 +562,17 @@ function wpm_set_new_value( $old_value, $new_value, $config = array(), $lang = '
 	}
 
 	$old_value = wpm_value_to_ml_array( $old_value );
-	$value     = wpm_set_language_value( $old_value, $new_value, $config, $lang );
-	$value     = wpm_ml_value_to_string( $value );
+
+	if ( wpm_is_ml_array( $old_value ) ) {
+		foreach ($old_value as $key => $lang_value) {
+			if ( strpos($lang_value, '{"') || strpos($lang_value, ':{"') || strpos($lang_value, '""')  || strpos($lang_value, '":"') ) {
+				$old_value[ $key ] = wp_slash( $lang_value );
+			}
+		}
+	}
+
+	$value = wpm_set_language_value( $old_value, $new_value, $config, $lang );
+	$value = wpm_ml_value_to_string( $value );
 
 	return $value;
 }


### PR DESCRIPTION
```bash
WordPress v5.2.1
Carbon Fields v3.1 #from composer
WP-Multilang v3.6.4
PHP v7.2.17-0ubuntu0.18.04.1
```

## Situation
Create Gutenberg Block with Carbonfields, and use `rich_edit` (WordPress tinyMCE WYSIWYG editor) fields inside Gutenberg Block.

### On Save page or post
**posted/saved** data from `rich_text` field
`[:ru]<!-- wp:carbon-fields/ ... \"content\":\"\\u003cp\\u003e\\...`
`[:ru]<!-- wp:carbon-fields/ ... \"content":"\u003cp\u003e\...`

WordPress clean slashes and stored data to db.

## Problem
On save page/post, post data for currently edited language well escaped and well stored to db, but data for other languages, currently stored with one `\` escaped and cleaned again on save.

After save we have this
`[:ru]<!-- wp:carbon-fields/ ... \"content":"\u003cp\u003e\...`
`[:en]<!-- wp:carbon-fields/ ... \"content":"u003cpu003e...`

For English we loose all escaped tags and symbols.