### PR TITLE
Fix Admin Nav menu custom fields metabox not show. issue #92

### DIFF
--- a/includes/admin/class-wpm-admin-edit-menus.php
+++ b/includes/admin/class-wpm-admin-edit-menus.php
@@ -17,13 +17,36 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WPM_Admin_Edit_Menus {
 
 	/**
-	 * WPM_Admin_Menus constructor.
+	 * WPM_Admin_Edit_Menus constructor.
 	 */
 	public function __construct() {
+
 		add_filter( 'manage_nav-menus_columns', array( $this, 'nav_menu_manage_columns' ), 11 );
-		add_action( 'wp_update_nav_menu_item', array( $this, 'wp_update_nav_menu_item_action' ), 10, 2 );
+		add_action( 'wp_update_nav_menu_item', array( $this, 'update_nav_menu_item' ), 10, 2 );
+		add_action( 'wp_update_nav_menu_item', array( $this, 'update_nav_menu_item_language_params' ), 10, 2 );
 		add_filter( 'wp_setup_nav_menu_item', array( $this, 'setup_nav_menu_item' ) );
+		add_filter( 'wp_edit_nav_menu_walker', array( $this, 'filter_walker' ) );
+	}
+
+	/**
+	 * Add custom field menu
+	 *
+	 * @wp_hook filter wp_edit_nav_menu_walker
+	 *
+	 * @param $class_name
+	 *
+	 * @return  string Walker class name
+	 */
+	public function filter_walker( $class_name ) {
+
+		if ( ! has_action('wp_nav_menu_item_custom_fields') ) {
+			$class_name = 'WPM\Includes\Libraries\WPM_Walker_Nav_Menu_Edit';
+		}
+
+		add_action( 'wp_nav_menu_item_custom_fields', array( $this, 'menu_item_languages_setting_custom_fields' ), 5, 2 );
 		add_action( 'wp_nav_menu_item_custom_fields', array( $this, 'menu_item_custom_fields' ), 15, 2 );
+
+		return $class_name;
 	}
 
 	/**
@@ -49,7 +72,7 @@ class WPM_Admin_Edit_Menus {
 	 * @param int   $menu_id         Nav menu ID
 	 * @param int   $menu_item_db_id Menu item ID
 	 */
-	public static function wp_update_nav_menu_item_action( $menu_id, $menu_item_db_id ) {
+	public static function update_nav_menu_item( $menu_id, $menu_item_db_id ) {
 		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
 			return;
 		}
@@ -73,6 +96,28 @@ class WPM_Admin_Edit_Menus {
 		} else {
 			delete_post_meta( $menu_item_db_id, '_' . $key );
 		}
+	}
+
+	/**
+	 * Add language settings params to menu item
+	 *
+	 * @param $menu_id
+	 * @param $menu_item_db_id
+	 */
+	public function update_nav_menu_item_language_params( $menu_id, $menu_item_db_id ) {
+
+		if( 'update' !== $_REQUEST['action'] ) {
+			return;
+		}
+
+		check_admin_referer( 'update-nav_menu', 'update-nav-menu-nonce' );
+
+		if ( empty( $_POST['menu-item-url'][ $menu_item_db_id ] ) || '#wpm-languages' !== $_POST['menu-item-url'][ $menu_item_db_id ] ) {
+			return;
+		}
+
+		update_post_meta( $menu_item_db_id, '_menu_item_languages_type', $_POST['languages_type'][ $menu_item_db_id ] );
+		update_post_meta( $menu_item_db_id, '_menu_item_languages_show', $_POST['languages_show'][ $menu_item_db_id ] );
 	}
 
 
@@ -117,6 +162,64 @@ class WPM_Admin_Edit_Menus {
 			<?php foreach ( $languages as $code => $language ) { if ( ! $language['enable'] ) continue; ?>
 			<label><input type="checkbox" name="<?php esc_attr_e( $name ); ?>[<?php echo esc_attr( $i ); ?>]" id="<?php echo $id . '-' . $code; ?>" value="<?php echo esc_attr( $code ); ?>"<?php checked( in_array( $code, $value ) ); ?>><?php echo esc_attr( $language['name'] ); ?></label><br>
 			<?php $i++; } ?>
+		</p>
+		<?php
+	}
+
+	/**
+	 * Add custom fields to menu item.
+	 *
+	 * @param int $item_id
+	 * @param object $item
+	 */
+	public function menu_item_languages_setting_custom_fields( $item_id, $item ) {
+
+		if ( '#wpm-languages' !== $item->url ) {
+			return;
+		}
+
+		$_key  = 'languages_type';
+		$key   = sprintf( 'menu-item-%s', $_key );
+		$id    = sprintf( 'edit-%s-%s', $key, $item_id );
+		$name  = sprintf( '%s[%s]', $_key, $item_id );
+		$value = get_post_meta( $item_id, '_menu_item_languages_type', true );
+		$class = sprintf( 'field-%s', $_key );
+
+		$type_options = array(
+			'inline'   => __( 'Inline', 'wp-multilang' ),
+			'single'   => __( 'Single', 'wp-multilang' ),
+			'dropdown' => __( 'Dropdown', 'wp-multilang' ),
+		);
+		?>
+		<p class="description description-wide <?php echo esc_attr( $class ); ?>">
+			<label for="<?php esc_attr_e( $id ); ?>"><?php esc_html_e( 'Languages menu item type', 'wp-multilang' ); ?></label>
+			<select class="widefat" id="<?php esc_attr_e( $id ); ?>" name="<?php esc_attr_e( $name ); ?>">
+				<?php foreach ( $type_options as $val => $name ) { ?>
+					<option value="<?php esc_attr_e( $val ); ?>"<?php selected( $val, $value ) ?>><?php esc_html_e( $name ); ?></option>
+				<?php } ?>
+			</select>
+		</p>
+		<?php
+		$_key  = 'languages_show';
+		$key   = sprintf( 'menu-item-%s', $_key );
+		$id    = sprintf( 'edit-%s-%s', $key, $item_id );
+		$name  = sprintf( '%s[%s]', $_key, $item_id );
+		$value = get_post_meta( $item_id, '_menu_item_languages_show', true );
+		$class = sprintf( 'field-%s', $_key );
+
+		$show_options = array(
+			'both' => __( 'Both', 'wp-multilang' ),
+			'flag' => __( 'Flag', 'wp-multilang' ),
+			'name' => __( 'Name', 'wp-multilang' ),
+		);
+		?>
+		<p class="description description-wide <?php echo esc_attr( $class ); ?>">
+			<label for="<?php esc_attr_e( $id ); ?>"><?php esc_html_e( 'Show', 'wp-multilang' ); ?></label>
+			<select class="widefat" id="<?php esc_attr_e( $id ); ?>" name="<?php esc_attr_e( $name ); ?>">
+				<?php foreach ( $show_options as $val => $name ) { ?>
+					<option value="<?php esc_attr_e( $val ); ?>"<?php selected( $val, $value ) ?>><?php esc_html_e( $name ); ?></option>
+				<?php } ?>
+			</select>
 		</p>
 		<?php
 	}

--- a/includes/admin/class-wpm-admin-menus.php
+++ b/includes/admin/class-wpm-admin-menus.php
@@ -24,30 +24,6 @@ class WPM_Admin_Menus {
 
 		// Add endpoints custom URLs in Appearance > Menus > Pages.
 		add_action( 'admin_head-nav-menus.php', array( $this, 'add_nav_menu_meta_boxes' ) );
-		add_filter( 'wp_edit_nav_menu_walker', array( $this, 'filter_walker' ) );
-		add_action( 'wp_nav_menu_item_custom_fields', array( $this, 'menu_item_languages_setting' ), 5, 2 );
-		add_action( 'wp_update_nav_menu_item', array( $this, 'update_nav_menu_item' ), 10, 2 );
-	}
-
-
-	/**
-	 * Replace default menu editor walker with ours
-	 *
-	 * We don't actually replace the default walker. We're still using it and
-	 * only injecting some HTMLs.
-	 *
-	 * @wp_hook filter wp_edit_nav_menu_walker
-	 *
-	 * @param $class_name
-	 *
-	 * @return  string Walker class name
-	 */
-	public static function filter_walker( $class_name ) {
-		if ( ! has_action( 'wp_nav_menu_item_custom_fields') ) {
-			return 'WPM\Includes\Libraries\WPM_Walker_Nav_Menu_Edit';
-		}
-
-		return $class_name;
 	}
 
 	/**
@@ -192,85 +168,5 @@ class WPM_Admin_Menus {
 			</p>
 		</div>
 		<?php
-	}
-
-	/**
-	 * Add custom fields to menu item.
-	 *
-	 * @param int $item_id
-	 * @param object $item
-	 */
-	public function menu_item_languages_setting( $item_id, $item ) {
-
-		if ( '#wpm-languages' !== $item->url ) {
-			return;
-		}
-
-		$_key  = 'languages_type';
-		$key   = sprintf( 'menu-item-%s', $_key );
-		$id    = sprintf( 'edit-%s-%s', $key, $item_id );
-		$name  = sprintf( '%s[%s]', $_key, $item_id );
-		$value = get_post_meta( $item_id, '_menu_item_languages_type', true );
-		$class = sprintf( 'field-%s', $_key );
-
-		$type_options = array(
-			'inline'   => __( 'Inline', 'wp-multilang' ),
-			'single'   => __( 'Single', 'wp-multilang' ),
-			'dropdown' => __( 'Dropdown', 'wp-multilang' ),
-		);
-		?>
-		<p class="description description-wide <?php echo esc_attr( $class ); ?>">
-			<label for="<?php esc_attr_e( $id ); ?>"><?php esc_html_e( 'Languages menu item type', 'wp-multilang' ); ?></label>
-			<select class="widefat" id="<?php esc_attr_e( $id ); ?>" name="<?php esc_attr_e( $name ); ?>">
-				<?php foreach ( $type_options as $val => $name ) { ?>
-					<option value="<?php esc_attr_e( $val ); ?>"<?php selected( $val, $value ) ?>><?php esc_html_e( $name ); ?></option>
-				<?php } ?>
-			</select>
-		</p>
-		<?php
-		$_key  = 'languages_show';
-		$key   = sprintf( 'menu-item-%s', $_key );
-		$id    = sprintf( 'edit-%s-%s', $key, $item_id );
-		$name  = sprintf( '%s[%s]', $_key, $item_id );
-		$value = get_post_meta( $item_id, '_menu_item_languages_show', true );
-		$class = sprintf( 'field-%s', $_key );
-
-		$show_options = array(
-			'both' => __( 'Both', 'wp-multilang' ),
-			'flag' => __( 'Flag', 'wp-multilang' ),
-			'name' => __( 'Name', 'wp-multilang' ),
-		);
-		?>
-		<p class="description description-wide <?php echo esc_attr( $class ); ?>">
-			<label for="<?php esc_attr_e( $id ); ?>"><?php esc_html_e( 'Show', 'wp-multilang' ); ?></label>
-			<select class="widefat" id="<?php esc_attr_e( $id ); ?>" name="<?php esc_attr_e( $name ); ?>">
-				<?php foreach ( $show_options as $val => $name ) { ?>
-					<option value="<?php esc_attr_e( $val ); ?>"<?php selected( $val, $value ) ?>><?php esc_html_e( $name ); ?></option>
-				<?php } ?>
-			</select>
-		</p>
-		<?php
-	}
-
-	/**
-	 * Add language settings params
-	 *
-	 * @param $menu_id
-	 * @param $menu_item_db_id
-	 */
-	public function update_nav_menu_item( $menu_id, $menu_item_db_id ) {
-
-		if( 'update' !== $_REQUEST['action'] ) {
-			return;
-		}
-
-		check_admin_referer( 'update-nav_menu', 'update-nav-menu-nonce' );
-
-		if ( empty( $_POST['menu-item-url'][ $menu_item_db_id ] ) || '#wpm-languages' !== $_POST['menu-item-url'][ $menu_item_db_id ] ) {
-			return;
-		}
-
-		update_post_meta( $menu_item_db_id, '_menu_item_languages_type', $_POST['languages_type'][ $menu_item_db_id ] );
-		update_post_meta( $menu_item_db_id, '_menu_item_languages_show', $_POST['languages_show'][ $menu_item_db_id ] );
 	}
 }


### PR DESCRIPTION
Because has_action('wp_nav_menu_item_custom_fields') is always true.
The add_action( 'wp_nav_menu_item_custom_fields' is execute before the hook 'wp_edit_nav_menu_walker' for filter_walker.