### PR TITLE
Fix translation of the "title" attribute in the shortcode for copying, on the form edit page

### DIFF
--- a/includes/integrations/class-wpm-cf7.php
+++ b/includes/integrations/class-wpm-cf7.php
@@ -23,6 +23,8 @@ class WPM_CF7 {
 	public function __construct() {
 		add_filter( 'wpcf7_special_mail_tags', array( $this, 'add_language_tag' ), 10, 2 );
 		add_filter( 'wpcf7_form_hidden_fields', array( $this, 'add_lang_field' ) );
+
+		add_action( 'wpcf7_contact_form', array( $this, 'edit_form_translate_shortcode_title_attr' ), 10, 1 );
 	}
 
 	public function add_language_tag( $output, $name ) {
@@ -47,5 +49,14 @@ class WPM_CF7 {
 		$fields['lang'] = wpm_get_language();
 
 		return $fields;
+	}
+
+	/**
+	 * Fix translation of the "title" attribute in the shortcode for copying, on the form edit page
+	 *
+	 * @param $wpcf7 current Contacts Form 7 instance
+	 */
+	public function edit_form_translate_shortcode_title_attr( $wpcf7 ) {
+		$wpcf7->set_title( wpm_translate_string( $wpcf7->title() ) );
 	}
 }


### PR DESCRIPTION
WordPress `v5.3.2`
WP-Multilang `v2.4.1`

### Issue

![2019-12-26_11-55-46](https://user-images.githubusercontent.com/5267816/71463488-5e7eaa00-27d8-11ea-97e1-120a1e5c22ce.png)

### Fixed

![2019-12-26_11-55-08](https://user-images.githubusercontent.com/5267816/71463516-735b3d80-27d8-11ea-9617-0f5c86b3d4a4.png)
