### PR TITLE
Fixed post title "Auto Draft" bug

### DIFF
--- a/includes/class-wpm-posts.php
+++ b/includes/class-wpm-posts.php
@@ -179,6 +179,14 @@ class WPM_Posts extends WPM_Object {
 
 				if ( $post_id ) {
 					$old_value = get_post_field( $key, $post_id, 'edit' );
+
+					// Override "(Auto Draft)" new post default title with empty string.
+					if ( 'post_title' === $key ) {
+						$old_post_status = get_post_field( 'post_status', $post_id, 'edit' );
+						if ( 'auto-draft' === $old_post_status ) {
+							$old_value = '';
+						}
+					}
 				} else {
 					$old_value = '';
 				}


### PR DESCRIPTION
When you create a post in a language other than the default, a version of the post in the default language is automatically created with the title "Auto Draft". This PR should fix it.

How to reproduce it:
1. Install a fresh WordPress (in my case, in English).
2. Install the WP Multilang plugin.
3. Add an additional language in Settings -> Languages. For example, Russian.
4. Go to the Posts section, select the "Russian" tab above the list of posts and click the Add New button.
5. Add any content and click the Publish button.
6. Now you can see that in addition to the Russian version, an English version has also been created with the title "Auto draft".