### PR TITLE
Fixed display of alternate links when languages are selected in WP Dashboard

### DIFF
--- a/includes/wpm-template-functions.php
+++ b/includes/wpm-template-functions.php
@@ -125,7 +125,7 @@ function wpm_set_alternate_links() {
 
 	foreach ( wpm_get_languages() as $code => $language ) {
 
-		if ( $languages && ! isset( $languages[ $code ] ) ) {
+		if ( $languages && ! in_array( $code, $languages, true ) ) {
 			continue;
 		}
 


### PR DESCRIPTION
Alternate links are not displayed for posts, categories, tags, etc., if the languages in which they should be displayed are selected in the admin panel. This PR fixes it.