### PR TITLE
Support Multi Parts Lang Code Switch

### DIFF
--- a/includes/admin/class-wpm-admin-assets.php
+++ b/includes/admin/class-wpm-admin-assets.php
@@ -204,7 +204,7 @@ class WPM_Admin_Assets {
 					var query = document.location.search;
 					var href = '';
 					if (query.search(/edit_lang=/i) !== -1) {
-						href = url + query.replace(/edit_lang=[a-z]{2,4}(-[a-z]{2,4})?/i, 'edit_lang=' + lang) + document.location.hash;
+						href = url + query.replace(/edit_lang=[a-z]{2,4}((-[a-z]{2,4})?)*/i, 'edit_lang=' + lang) + document.location.hash;
 					} else {
 						href = url + query + '&edit_lang=' + lang + document.location.hash;
 					}

--- a/includes/admin/class-wpm-admin-assets.php
+++ b/includes/admin/class-wpm-admin-assets.php
@@ -204,7 +204,7 @@ class WPM_Admin_Assets {
 					var query = document.location.search;
 					var href = '';
 					if (query.search(/edit_lang=/i) !== -1) {
-						href = url + query.replace(/edit_lang=[a-z]{2,4}/i, 'edit_lang=' + lang) + document.location.hash;
+						href = url + query.replace(/edit_lang=[a-z]{2,4}(-[a-z]{2,4})?/i, 'edit_lang=' + lang) + document.location.hash;
 					} else {
 						href = url + query + '&edit_lang=' + lang + document.location.hash;
 					}


### PR DESCRIPTION
Example:
from `ko-kr` switch to `en` the query will become `en-kr` instead of `en`

New Regex:
![image](https://github.com/VaLeXaR/wp-multilang/assets/46896789/0a4a5514-14fd-4850-8337-3ae40c8b4954)

Old Regex:
![image](https://github.com/VaLeXaR/wp-multilang/assets/46896789/f8e712fc-bc0a-4f2a-989f-f70b24eb4f90)
